### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+indent_size = unset


### PR DESCRIPTION
# Pull Request

## Description

This change introduces an `.editorconfig` file to establish consistent coding styles across the project. The file sets up the following rules:

- UTF-8 character encoding
- Unix-style line endings (LF)
- 2-space indentation for most files
- Space-based indentation
- Insertion of a final newline at the end of files
- Trimming of trailing whitespace

For Markdown files specifically, the indentation size is left unspecified to allow for more flexible formatting.

These standardised settings will help maintain code consistency and improve collaboration among developers working on the project.