### PR TITLE
Add Markdown link checker workflow

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,5 @@
+dirs:
+  - ./
+  - ./docs
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -30,3 +30,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
+
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.1
+        with:
+          fetch-depth: 0
+
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new GitHub Actions workflow step to check Markdown links in the repository. The workflow utilises the UmbrellaDocs/action-linkspector action to validate links in Markdown files.

A new configuration file, `.linkspector.yml`, has been added to specify the directories to scan and the acceptable HTTP status codes for live links.

The code-quality.yml workflow file has been updated to include this new step, which will run alongside existing linting checks. The step is configured to fail on errors and provide feedback via GitHub PR reviews.

This addition will help maintain the quality and reliability of documentation by ensuring all links remain valid.