### PR TITLE
Add Dependency Review GitHub workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4.3.5


### PR DESCRIPTION
# Pull Request

## Description

This change introduces a new GitHub Actions workflow for dependency review. The workflow, named "Dependency Review", is triggered on pull request events, specifically when a pull request is opened, synchronised, reopened, or marked as ready for review.

The workflow runs on the latest Ubuntu environment and consists of two main steps:

1. Checking out the repository using `actions/checkout@v4.2.2`.
2. Running the dependency review action using `actions/dependency-review-action@v4.3.5`.

This addition enhances the project's security by automatically reviewing dependencies in pull requests, helping to identify and address potential vulnerabilities or issues in third-party packages.