### PR TITLE
Add .gitattributes to detect Markdown files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
# Pull Request

## Description

This change adds a `.gitattributes` file to the repository with a single entry: `*.md linguist-detectable`. This configuration ensures that Markdown files are recognised and included in the repository's language statistics on platforms like GitHub. It allows for better representation of the project's composition, especially for repositories with significant documentation or text content in Markdown format.