### PR TITLE
Move PR template to .github directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A set of tasks to set up a new repository.
 
 ### General
 
-- Add a `pull_request_template.md` file to the root of the repository.
+- Add a `pull_request_template.md` to the `.github` directory.
 - Add a `.editorconfig` file to the root of the repository.
 - Add a `LICENSE` file to the root of the repository. If one wasn't created with the repository.
 - Add a `README.md` file to the root of the repository.


### PR DESCRIPTION
# Pull Request

## Description

Updates the documentation to specify that the `pull_request_template.md` file should be placed in the `.github` directory instead of the repository root.