### PR TITLE
Update GitHub Actions Dependabot Groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -10,6 +9,9 @@ updates:
       timezone: "Europe/London"
     target-branch: "main"
     groups:
-      github-action-dependencies:
+      github-actions:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the `.github/dependabot.yml` file to improve the configuration for maintaining dependencies for GitHub Actions. The most important changes include renaming a group and specifying update types for dependencies.

Configuration improvements:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L3): Removed a comment related to maintaining dependencies for GitHub Actions.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L13-R17): Renamed the `github-action-dependencies` group to `github-actions` and specified that only `patch` and `minor` updates should be applied for dependencies in this group.