### PR TITLE
Check Justfile Format

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -52,6 +52,20 @@ jobs:
           fail_on_error: true
           filter_mode: nofilter
 
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Check Justfile Format
+        run: just format-check
+
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job in the GitHub Actions workflow to ensure the proper formatting of the `Justfile`. The most important change is the addition of the `check-justfile-format` job.

Improvements to GitHub Actions workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R55-R68): Added a new job `check-justfile-format` to verify the format of the `Justfile`. This job includes steps to checkout the repository, set up `just`, and run the `just format-check` command.