### PR TITLE
Update SuperLinter Permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,11 +26,11 @@ jobs:
           persist-credentials: false
       # Lint and Format everything
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.2.1
+        uses: super-linter/super-linter/slim@v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `Lint Code Base` job in the `.github/workflows/code-checks.yml` file. The change updates the version of the `super-linter` action and corrects the token secret name.

* Updated `super-linter` action version from `v7.2.1` to `v7.3.0`. (`[.github/workflows/code-checks.ymlL29-R33](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L29-R33)`)
* Corrected the token secret name from `GH_TOKEN` to `GITHUB_TOKEN`. (`[.github/workflows/code-checks.ymlL29-R33](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L29-R33)`)
