### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.1
+        uses: UmbrellaDocs/action-linkspector@v1.3.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.3.1
+        uses: astral-sh/setup-uv@v5.4.0
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -88,7 +88,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.13
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -103,7 +103,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.3.1
+        uses: astral-sh/setup-uv@v5.4.0
         with:
           version: "latest"
       - name: Run Lefthook Validate
@@ -121,10 +121,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.10
+        uses: github/codeql-action/init@v3.28.13
         with:
           languages: actions
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.10
+        uses: github/codeql-action/analyze@v3.28.13


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several updates to the `.github/workflows/code-checks.yml` file. The changes primarily involve updating the versions of various GitHub Actions used in the workflow.

Version updates:

* Updated `UmbrellaDocs/action-linkspector` from `v1.3.1` to `v1.3.2` for checking Markdown links.
* Updated `astral-sh/setup-uv` from `v5.3.1` to `v5.4.0` for installing the latest version of `uv`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L83-R91) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L106-R106)
* Updated `github/codeql-action/upload-sarif` from `v3.28.10` to `v3.28.13` for uploading SARIF files.
* Updated `github/codeql-action/init` from `v3.28.10` to `v3.28.13` for initializing CodeQL.
* Updated `github/codeql-action/analyze` from `v3.28.10` to `v3.28.13` for performing CodeQL analysis.
