### PR TITLE
Bump GitHub Action Versions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.3
+        uses: UmbrellaDocs/action-linkspector@v1.3.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.0
+        uses: astral-sh/setup-uv@v5.4.1
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -88,7 +88,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.13
+        uses: github/codeql-action/upload-sarif@v3.28.15
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -103,7 +103,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.0
+        uses: astral-sh/setup-uv@v5.4.1
         with:
           version: "latest"
       - name: Run Lefthook Validate
@@ -121,10 +121,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.13
+        uses: github/codeql-action/init@v3.28.15
         with:
           languages: actions
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.13
+        uses: github/codeql-action/analyze@v3.28.15

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -46,6 +46,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4.5.0
+        uses: actions/dependency-review-action@v4.6.0
         with:
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to several GitHub Actions in workflow files to use newer versions of the actions. The most important changes are the version updates for various actions in the `.github/workflows/code-checks.yml` and `.github/workflows/pull-request-tasks.yml` files.

Version updates in `.github/workflows/code-checks.yml`:

* Updated `UmbrellaDocs/action-linkspector` from `v1.3.3` to `v1.3.4` for checking Markdown links.
* Updated `astral-sh/setup-uv` from `v5.4.0` to `v5.4.1` for installing the latest version of uv. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L83-R91) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L106-R106)
* Updated `github/codeql-action/upload-sarif` from `v3.28.13` to `v3.28.15` for uploading SARIF files.
* Updated `github/codeql-action/init` and `github/codeql-action/analyze` from `v3.28.13` to `v3.28.15` for initializing and performing CodeQL analysis.

Version updates in `.github/workflows/pull-request-tasks.yml`:

* Updated `actions/dependency-review-action` from `v4.5.0` to `v4.6.0` for dependency review.