### PR TITLE
Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration to use a more flexible scheduling format for GitHub Actions dependency updates.

Configuration changes:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R7): Changed the `schedule` for the `github-actions` package ecosystem from a daily interval with a fixed time and timezone to a cron-based schedule (`30 7 * * *`). This allows for more precise control over when updates are checked.