### PR TITLE
Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,20 @@
 version: 2
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to enhance the scheduling and grouping of dependency updates. The most important changes include specifying a timezone for the cron job and refining the grouping rules for GitHub Actions updates.

Enhancements to Dependabot configuration:

* Added the `timezone` field to specify "Europe/London" for the cron job schedule.
* Updated the `github-actions` group to apply specifically to "version-updates" and exclude patterns matching "super-linter/*".