### PR TITLE
Update checkout action to V5

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -23,7 +23,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow configuration to use a newer version of the checkout action. This ensures the workflow benefits from the latest features and security updates.

Workflow dependency update:

* Updated the `actions/checkout` action from version `v4.2.2` to `v5.0.0` in `.github/workflows/code-checks.yml` to improve reliability and security.