### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A set of tasks to set up a new repository.
 
 - Add a `pull_request_template.md` to the `.github` directory.
 - Add a `.editorconfig` file to the root of the repository.
-- Add a `LICENSE` file to the root of the repository. If one wasn't created with the repository.
+- Add a `LICENCE` file to the root of the repository. If one wasn't created with the repository.
 - Add a `README.md` file to the root of the repository.
   - Add project status badges to the `README.md` file.
 - Set up a `CODE_OF_CONDUCT.md` file to the root of the repository.


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates references to the license file in the repository configuration and documentation to use the British English spelling "LICENCE" instead of "LICENSE".

Documentation and configuration updates:

* Updated the `README.md` setup instructions to refer to `LICENCE` instead of `LICENSE`.
* Changed the file pattern in `.github/other-configurations/labeller.yml` to match `LICENCE` instead of `LICENSE`.